### PR TITLE
Update purefb_fs.py

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_fs.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_fs.py
@@ -530,7 +530,7 @@ def delete_fs(module, blade):
 
             if module.params['eradicate']:
                 try:
-                    blade.file_systems.delete_file_systems(module.params['name'])
+                    blade.file_systems.delete_file_systems(name=module.params['name'])
                 except Exception:
                     module.fail_json(msg="Failed to delete filesystem {0}.".format(module.params['name']))
         except Exception:


### PR DESCRIPTION
My ansible playbook fails deleting a filesystem with the following:

TASK [Remove backing filesystem] *********************************************************************************************************************************************************************************
fatal: [sn1-r740-d03-13]: FAILED! => {"changed": false, "msg": "Failed to delete filesystem elasticsearch-pipeline."}

Specify named parameter to delete_file_systems() call.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request
- New Role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
